### PR TITLE
Made hop_length explicit to avoid surprises.

### DIFF
--- a/superchip/transcribe_f0.py
+++ b/superchip/transcribe_f0.py
@@ -116,6 +116,7 @@ def interp_hcqt(audio_fpath=None, y=None, fs=None):
     n_bins_master = int(np.ceil(np.log2(np.max(HARMONICS))) * BINS_PER_OCTAVE) + n_bins_plane
 
     cqt_master = np.abs(librosa.cqt(y=y, sr=fs,
+                                    hop_length=HOP_LENGTH,
                                     fmin=FMIN,
                                     n_bins=n_bins_master,
                                     bins_per_octave=BINS_PER_OCTAVE))


### PR DESCRIPTION
Super minor change, making the `hop_length` parameter for the CQT explicit in `interp_hcqt` to avoid surprises should the "constant" `HOP_LENGTH` ever change.

Just stumbled across this when reading your code. Feel free to ignore.